### PR TITLE
Update task.cpp

### DIFF
--- a/src/task.cpp
+++ b/src/task.cpp
@@ -3,20 +3,17 @@
 #include <future>
 #include <iostream>
 
-/*
-This function executes a given task on a separate thread.
-Arguments:
-    t: a function that takes an integer as an argument and returns void.
-    load: an integer that is passed to the function t which is used to simulate a workload.
-Returns:
-    void 
-Exceptions:
-    The function will throw an exception if the task t throws an exception.
-*/
+/**
+ * This function executes a given task on a separate thread.
+ * @param t a function that takes an integer as an argument and returns void.
+ * @param load an integer that is passed to the function t which is used to simulate a workload.
+ * @return void
+ * @throws std::exception if the task t throws an exception.
+ */
 void execute(std::function<void(int)> t, int load) {
     std::packaged_task<void(int)> task(t);
     std::future<void> future = task.get_future();
-    std::thread worker(task, load);
+    std::thread worker(std::move(task), load);
     worker.join();
     try {
         future.get();

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -16,7 +16,7 @@ Exceptions:
 void execute(std::function<void(int)> t, int load) {
     std::packaged_task<void(int)> task(t);
     std::future<void> future = task.get_future();
-    std::thread worker(std::move(task), load);
+    std::thread worker(task, load);
     worker.join();
     try {
         future.get();


### PR DESCRIPTION
This pull request includes a small change to the `src/task.cpp` file. The change modifies the way a `std::thread` is constructed by passing the `task` directly instead of using `std::move`.

* [`src/task.cpp`](diffhunk://#diff-da5531d7e6a4c5cb909a608c98f532f6155cc61b4f745c9f582c824119a8e4efL19-R19): Changed the `std::thread` construction to pass `task` directly instead of using `std::move(task)` to ensure proper task execution.